### PR TITLE
feat(lint): add local oxlint JS plugin with domain-no-infra-imports rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,5 +4,9 @@
   "options": {
     "typeAware": true,
     "typeCheck": true
+  },
+  "jsPlugins": ["./tools/oxlint-plugins/index.js"],
+  "rules": {
+    "starter-cloudflare/domain-no-infra-imports": "error"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This project uses **Vite 8**, **Vitest 4**, **oxlint**, **oxfmt**, and **pnpm** 
 
 ### Code Quality
 
-- `pnpm lint` - Lint and auto-fix with oxlint
+- `pnpm lint` - Lint and auto-fix with oxlint (includes local `starter-cloudflare/*` JS plugin rules in `tools/oxlint-plugins/`)
 - `pnpm format` - Format code with oxfmt
 - `pnpm ci` - Full CI check: lint, format, and typecheck
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vitest/browser": "^4.1.2",
     "@vitest/browser-playwright": "^4.1.2",
     "@vitest/coverage-v8": "^4.1.2",
+    "acorn": "^8.16.0",
     "drizzle-kit": "^0.31.8",
     "happy-dom": "^20.0.11",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.2
         version: 4.1.2(@vitest/browser@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2))(vitest@4.1.2)
+      acorn:
+        specifier: ^8.16.0
+        version: 8.16.0
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.10

--- a/tools/oxlint-plugins/README.md
+++ b/tools/oxlint-plugins/README.md
@@ -1,0 +1,20 @@
+# starter-cloudflare oxlint plugin
+
+Local oxlint JS plugin with architectural lint rules for this repo. Loaded via `jsPlugins` in `.oxlintrc.json`.
+
+## Rules
+
+- `starter-cloudflare/domain-no-infra-imports` — forbids imports from `src/infra/**` in files under `src/domain/**`. Matches static imports, re-exports, and string-literal dynamic `import()`. Covers both the `@infra/*` path alias and relative paths that resolve into `src/infra/`.
+
+## Adding a rule
+
+1. Create `rules/<rule-name>.js` exporting `{ meta, create(context) }` (ESLint v9 compatible shape).
+2. Register it in `index.js` under `rules`.
+3. Enable it in `.oxlintrc.json` under `rules` (prefixed with `starter-cloudflare/`).
+4. Drive the implementation with a co-located `rules/<rule-name>.unit.test.ts` using `test-utils/rule-tester.ts`.
+
+## Constraints
+
+- Plain ESM `.js` source — no build step; oxlint `import()`s directly.
+- oxlint's JS-plugin runtime does not support type-aware rules or custom parsers (alpha).
+- Tests use a minimal in-tree `RuleTester` built on `acorn` (ES modules). Keep rule tests snippet-sized; full-file TS parsing is out of scope.

--- a/tools/oxlint-plugins/index.js
+++ b/tools/oxlint-plugins/index.js
@@ -1,0 +1,8 @@
+import domainNoInfraImports from './rules/domain-no-infra-imports.js'
+
+export default {
+  meta: { name: 'starter-cloudflare' },
+  rules: {
+    'domain-no-infra-imports': domainNoInfraImports,
+  },
+}

--- a/tools/oxlint-plugins/rules/domain-no-infra-imports.js
+++ b/tools/oxlint-plugins/rules/domain-no-infra-imports.js
@@ -1,0 +1,52 @@
+import path from 'node:path'
+
+const MESSAGE =
+  'src/domain must not import from src/infra — domain is the pure core. Move the shared code to src/domain/, or invert the dependency via an interface injected at the infra boundary.'
+
+function isInfraSource(sourceValue, filename, cwd) {
+  if (typeof sourceValue !== 'string' || sourceValue.length === 0) return false
+  if (/^@infra(\/|$)/.test(sourceValue)) return true
+  if (sourceValue.startsWith('.')) {
+    const resolved = path.resolve(path.dirname(filename), sourceValue)
+    const infraRoot = path.resolve(cwd, 'src/infra') + path.sep
+    return (resolved + path.sep).startsWith(infraRoot)
+  }
+  return false
+}
+
+function isInsideDomain(filename, cwd) {
+  const domainRoot = path.resolve(cwd, 'src/domain') + path.sep
+  return (filename + path.sep).startsWith(domainRoot)
+}
+
+export default {
+  meta: { type: 'problem' },
+  create(context) {
+    const filename = context.getFilename()
+    const cwd = typeof context.getCwd === 'function' ? context.getCwd() : process.cwd()
+    if (!isInsideDomain(filename, cwd)) return {}
+
+    const check = (source) => {
+      if (source && isInfraSource(source.value, filename, cwd)) {
+        context.report({ message: MESSAGE, node: source })
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        check(node.source)
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) check(node.source)
+      },
+      ExportAllDeclaration(node) {
+        check(node.source)
+      },
+      ImportExpression(node) {
+        if (node.source?.type === 'Literal' && typeof node.source.value === 'string') {
+          check(node.source)
+        }
+      },
+    }
+  },
+}

--- a/tools/oxlint-plugins/rules/domain-no-infra-imports.unit.test.ts
+++ b/tools/oxlint-plugins/rules/domain-no-infra-imports.unit.test.ts
@@ -1,0 +1,109 @@
+import path from 'node:path'
+import { describe, it } from 'vitest'
+import rawRule from './domain-no-infra-imports.js'
+import { runRuleTester, type Rule } from '../test-utils/rule-tester'
+
+const rule = rawRule as Rule
+
+const cwd = '/repo'
+const domainFile = path.join(cwd, 'src/domain/user/service.ts')
+const infraFile = path.join(cwd, 'src/infra/db/client.ts')
+const webappFile = path.join(cwd, 'src/webapp/route.ts')
+
+const MESSAGE =
+  'src/domain must not import from src/infra — domain is the pure core. Move the shared code to src/domain/, or invert the dependency via an interface injected at the infra boundary.'
+
+describe('starter-cloudflare/domain-no-infra-imports', () => {
+  it('flags infra imports from domain files and ignores non-domain files', () => {
+    runRuleTester(rule, {
+      valid: [
+        {
+          name: 'domain file importing from @domain alias',
+          filename: domainFile,
+          cwd,
+          code: `import { User } from '@domain/user/model'`,
+        },
+        {
+          name: 'domain file importing external package',
+          filename: domainFile,
+          cwd,
+          code: `import React from 'react'`,
+        },
+        {
+          name: 'domain file with relative import staying inside src/domain',
+          filename: domainFile,
+          cwd,
+          code: `import { shared } from '../shared/util'`,
+        },
+        {
+          name: 'non-domain file importing from @infra is ignored',
+          filename: webappFile,
+          cwd,
+          code: `import { db } from '@infra/db'`,
+        },
+        {
+          name: 'non-domain file importing relatively into infra is ignored',
+          filename: infraFile,
+          cwd,
+          code: `import { other } from './other'`,
+        },
+        {
+          name: 'domain file dynamically importing a domain module',
+          filename: domainFile,
+          cwd,
+          code: `await import('@domain/user/model')`,
+        },
+        {
+          name: 'domain file with non-literal dynamic import is not flagged',
+          filename: domainFile,
+          cwd,
+          code: `const name = 'x'; await import(name)`,
+        },
+      ],
+      invalid: [
+        {
+          name: 'static import from @infra alias',
+          filename: domainFile,
+          cwd,
+          code: `import { db } from '@infra/db'`,
+          errors: [{ message: MESSAGE }],
+        },
+        {
+          name: 'side-effect import from @infra alias',
+          filename: domainFile,
+          cwd,
+          code: `import '@infra/db/client'`,
+          errors: [{ message: MESSAGE }],
+        },
+        {
+          name: 'named re-export from @infra',
+          filename: domainFile,
+          cwd,
+          code: `export { something } from '@infra/thing'`,
+          errors: [{ message: MESSAGE }],
+        },
+        {
+          name: 'star re-export from @infra',
+          filename: domainFile,
+          cwd,
+          code: `export * from '@infra/thing'`,
+          errors: [{ message: MESSAGE }],
+        },
+        {
+          name: 'dynamic import from @infra',
+          filename: domainFile,
+          cwd,
+          code: `await import('@infra/db')`,
+          errors: [{ message: MESSAGE }],
+        },
+        {
+          name: 'relative escape into src/infra',
+          filename: domainFile,
+          cwd,
+          code: `import x from '../../infra/db'`,
+          errors: [{ message: MESSAGE }],
+        },
+      ],
+    })
+  })
+})

--- a/tools/oxlint-plugins/test-utils/rule-tester.ts
+++ b/tools/oxlint-plugins/test-utils/rule-tester.ts
@@ -1,0 +1,100 @@
+import { expect } from 'vitest'
+import * as acorn from 'acorn'
+
+type Visitor = (node: any) => void
+type VisitorMap = Record<string, Visitor>
+
+export type RuleContext = {
+  getFilename: () => string
+  getCwd: () => string
+  sourceCode: { text: string }
+  report: (descriptor: { message: string; node: any }) => void
+}
+
+export type Rule = {
+  meta?: { type?: string }
+  create: (context: RuleContext) => VisitorMap
+}
+
+export type ValidCase = {
+  name?: string
+  filename: string
+  cwd?: string
+  code: string
+}
+
+export type InvalidCase = ValidCase & {
+  errors: Array<{ message?: string | RegExp }>
+}
+
+function parse(code: string): any {
+  return acorn.parse(code, {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+    allowImportExportEverywhere: true,
+  })
+}
+
+const SKIP_KEYS = new Set(['loc', 'range', 'start', 'end'])
+
+function walk(node: any, visitors: VisitorMap): void {
+  if (!node || typeof node.type !== 'string') return
+  const visitor = visitors[node.type]
+  if (visitor) visitor(node)
+  for (const key of Object.keys(node)) {
+    if (SKIP_KEYS.has(key)) continue
+    const child = (node as any)[key]
+    if (!child) continue
+    if (Array.isArray(child)) {
+      for (const item of child) walk(item, visitors)
+    } else if (typeof child === 'object' && typeof child.type === 'string') {
+      walk(child, visitors)
+    }
+  }
+}
+
+function runRule(
+  rule: Rule,
+  { filename, cwd, code }: { filename: string; cwd?: string; code: string },
+): Array<{ message: string }> {
+  const effectiveCwd = cwd ?? process.cwd()
+  const collected: Array<{ message: string }> = []
+  const ctx: RuleContext = {
+    getFilename: () => filename,
+    getCwd: () => effectiveCwd,
+    sourceCode: { text: code },
+    report: (d) => {
+      collected.push({ message: d.message })
+    },
+  }
+  const visitors = rule.create(ctx)
+  walk(parse(code), visitors)
+  return collected
+}
+
+export function runRuleTester(
+  rule: Rule,
+  cases: { valid: Array<ValidCase>; invalid: Array<InvalidCase> },
+): void {
+  for (const c of cases.valid) {
+    const reports = runRule(rule, c)
+    expect(
+      reports,
+      `valid case ${c.name ?? c.filename} should produce no diagnostics but produced: ${JSON.stringify(reports)}`,
+    ).toEqual([])
+  }
+  for (const c of cases.invalid) {
+    const reports = runRule(rule, c)
+    expect(
+      reports.length,
+      `invalid case ${c.name ?? c.filename} expected ${c.errors.length} diagnostic(s), got ${reports.length}`,
+    ).toBe(c.errors.length)
+    c.errors.forEach((expected, i) => {
+      if (expected.message instanceof RegExp) {
+        expect(reports[i].message).toMatch(expected.message)
+      } else if (typeof expected.message === 'string') {
+        expect(reports[i].message).toBe(expected.message)
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Stands up a local oxlint JS plugin at `tools/oxlint-plugins/` (loaded via `jsPlugins` in `.oxlintrc.json`) with a first rule `starter-cloudflare/domain-no-infra-imports` that flags static imports, re-exports, and string-literal dynamic `import()`s from `src/domain/**` files whose source resolves into `src/infra/**` (both `@infra/*` alias and relative escapes).
- Adds a co-located Vitest `RuleTester` harness (`acorn` parser, acorn added as devDep) and 13 test cases covering valid/invalid shapes; scaffold is reusable for future rules (one file in `rules/`, one entry in `index.js`, one line in `.oxlintrc.json`).
- Complements the existing `tsconfig.domain.json` alias-strip by catching relative and dynamic import escapes at lint time with a clear architectural message.

## Test plan
- [x] `pnpm test:unit tools/oxlint-plugins` — rule tests pass
- [x] `pnpm oxlint` — clean on current tree
- [x] End-to-end: injected `import '@infra/db/client'` into `src/domain/shared/index.ts` and confirmed oxlint emits `starter-cloudflare(domain-no-infra-imports)` at the import site, then reverted
- [x] `pnpm typecheck:layers` — still green