### PR TITLE
docs(readme): codify hexagonal conventions and testing contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # starter-cloudflare
 
-A starter template for full-stack apps on **Cloudflare Workers** with **Vite 8**, **React 19**, **TanStack Start**, **Drizzle**, **Vitest 4**, and **pnpm**. See [`AGENTS.md`](./AGENTS.md) for the full toolchain reference and agent workflow notes.
+A starter template for full-stack apps on **Cloudflare Workers** with **Vite 8**, **React 19**, **TanStack Start**, **Drizzle**, **Vitest 4**, and **pnpm**. See [`AGENTS.md`](./AGENTS.md) for the full command reference.
+
+This README is both **descriptive** (what the repo enforces today) and **prescriptive** (the conventions you should keep if you adopt this starter). Commands and config details live in `AGENTS.md`; this file explains *why* they exist.
 
 ## Toolchain at a glance
 
@@ -38,6 +40,101 @@ pnpm ci
 
 See `AGENTS.md` for the complete command list and configuration details.
 
+## Architecture: Hexagonal / Ports & Adapters
+
+Business logic lives in pure TypeScript. Frameworks, databases, and external services are adapters plugged into ports. The goal is to express domain models and use cases without depending on the runtime, the HTTP server, the database driver, or the UI framework — so any of those can be swapped with near-zero rewrite to the core.
+
+**Layers:**
+
+- **`src/domain/**`** — one folder per subdomain of the application (`billing/`, `auth/`, `account/`, …). Each subdomain contains its own entities, value objects, use cases, and a `ports/` folder holding the interfaces it needs from the outside world (`UserRepository.interface.ts`, `EventPublisher.interface.ts`). No imports from `src/infra/**`, no framework globals, no Node/Workers APIs. May import from `src/utils/**`.
+- **`src/infra/**`** — adapter implementations, grouped by *technology concept* and then by *specific technology*: `database/postgres/user-repository.ts`, `messaging/kafka/event-publisher.ts`. Files are named after the *entity or capability* (`user-repository.ts`, `event-publisher.ts`) — never the technology, because the folder already denotes it. Nesting the concrete tech inside the concept makes it obvious what each adapter is fulfilling and keeps the swap path (e.g. `postgres/` → `sqlite/`) local. Infra depends on domain ports; the reverse is never allowed.
+- **`src/utils/**`** — thin wrappers over third-party libraries (`lodash`, `date-fns`, …). The escape hatch that lets domain code use common utilities without defining a port per library. The utility module *is* the port; the library is its implementation, swappable at the utility boundary.
+- **`src/api/**`** — HTTP composition root (Hono). Wires concrete adapters into use cases and exposes them as routes.
+- **`src/webapp/**`** — React + TanStack Start UI. Calls into the API; composes its own adapters where needed.
+
+**The boundary is enforced three times, on purpose:**
+
+1. **Path aliases** — `@domain/*` and `@infra/*` in `tsconfig.json` make the layer of every import readable at a glance.
+2. **Layered typechecks** — `tsconfig.domain.json` compiles the domain alone; `tsconfig.infra.json` compiles domain + infra. If domain code reaches into infra, the domain typecheck fails before anything else runs. `pnpm typecheck:layers` runs both.
+3. **Custom oxlint rule** — `starter-cloudflare/domain-no-infra-imports` (in `tools/oxlint-plugins/rules/`) blocks both static and dynamic imports from `src/infra/**` inside `src/domain/**` files.
+
+Any one of the three would catch most mistakes; all three together make the violation loud and local.
+
+## Directory layout
+
+```
+src/
+  domain/                       # one folder per subdomain; pure business logic + ports
+    billing/
+      ports/
+        InvoiceRepository.interface.ts
+      Invoice.ts
+    auth/
+      ports/
+        UserRepository.interface.ts
+      User.ts
+    account/
+      ...
+  infra/                        # adapters grouped by technology concept, then specific tech
+    database/
+      postgres/
+        user-repository.ts      # named for the entity; folder denotes the tech
+    messaging/
+      kafka/
+        event-publisher.ts
+  utils/                        # thin wrappers over 3rd-party libs (lodash, date-fns, ...)
+  api/                          # Hono server — composes domain + infra
+  webapp/                       # React + TanStack Start UI
+  server.ts                     # Cloudflare Workers entry
+tools/
+  oxlint-plugins/               # custom lint rules (e.g. domain-no-infra-imports)
+test/                           # shared test setup (database harness, factories)
+e2e/                            # Playwright specs
+```
+
+## Testing strategy
+
+Four test types. The filename tells you which, because it reads like the test type it is.
+
+| Type        | Filename                 | Purpose                                                                                                         | Tool                             | Coverage expectation              |
+| ----------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------- |
+| Unit        | `*.unit.test.ts`         | Behavioural units of domain logic                                                                               | Vitest                           | **100%** on domain                |
+| Browser     | `*.browser.test.ts`      | UI components interacting with real DOM APIs                                                                    | Vitest browser mode + Playwright | As needed per component           |
+| Integration | `*.integration.test.ts`  | Adapter implementations reaching real third-party boundaries — e.g. a Drizzle repository against a Postgres testcontainer, or an HTTP client against an MSW handler | Vitest (+ Testcontainers / MSW)  | At least one per adapter          |
+| E2E         | `*.e2e.test.ts`          | Full user flows across multiple routes — signup, login, the journeys that must always work                      | Playwright                       | Critical flows only (top priority)|
+
+Examples from the repo: `src/domain/shared/result.unit.test.ts`, `src/infra/drizzle/user-operations.integration.test.ts`, `e2e/home.e2e.test.ts`, and the oxlint plugin's `tools/oxlint-plugins/rules/domain-no-infra-imports.unit.test.ts`.
+
+Unit tests are the load-bearing layer: they run on every staged-file commit and every push, and they drive the 100% domain-coverage expectation. Integration tests verify that adapter code actually talks to the thing it claims to. E2E tests keep the most important journeys honest. Browser tests catch regressions in DOM-dependent behaviour that jsdom-style runners miss.
+
+## Schema & type modules
+
+Two filename suffixes mark modules that are pure declarations:
+
+- **`*.schema.ts`** — validation schemas (Zod or similar). No branching logic.
+- **`*.types.ts`** — type and interface declarations only.
+
+Both are **exempt from unit-test coverage demands**. They don't contain behaviour to verify; unit-testing them would only restate the declarations. Giving them explicit suffixes makes the exemption self-documenting and signals module intent at a glance.
+
+Rule of thumb: if a module contains only declarations, use one of these suffixes. If it contains behaviour, don't.
+
+## Quality gates
+
+Every stage has a specific job. Understanding the *why* matters as much as the commands.
+
+- **Pre-commit (lefthook)** — runs `oxlint --fix` and `oxfmt --write` on staged files (auto-restaged), then `vitest related --run --project unit` over the staged files. *Why*: keeps git history clean and readable (no "fix lint" commits), and ensures every commit is **independently releasable** — no commit silently breaks the behaviour of code near the change.
+- **Pre-push (lefthook)** — `vitest run --changed origin/master --project unit`. Catches regressions across the whole change set before they leave the machine.
+- **`pnpm ci`** (local + CI) — `oxlint && oxfmt --check . && pnpm typecheck:layers && pnpm fallow:ci`. Read-only quality gate; no fixes, no writes. The source of truth for "is this branch green?"
+- **GitHub Actions** — runs the same gate plus the test matrix (unit, browser, integration).
+
+To skip hooks for a single command (e.g. an intentional WIP commit), set `LEFTHOOK=0`.
+
+## Runtime choices
+
+- **Hono** as the HTTP server — deliberately runtime-agnostic. If Cloudflare Workers stops fitting (a cold-start regression, a pricing change, a feature Workers can't express), the Hono app moves to Node / Bun / Deno / a container with near-zero rewrite.
+- **Cloudflare Workers** as the starter runtime — chosen because it's exceptionally cheap and fast out of the box, with a global edge by default. Drizzle + Hyperdrive give Postgres access without managing a connection pool.
+- **The swap path** — `src/api/` is the composition boundary. Replace `src/server.ts` (the Workers entry) with a different runtime adapter to change runtime; the app factory does not change.
+
 ## Codebase intelligence (fallow)
 
 [fallow](https://github.com/fallow-rs/fallow) is a Rust-native, sub-second whole-project analyzer for TypeScript/JavaScript. It finds things oxlint's per-file model can't see:
@@ -58,6 +155,25 @@ pnpm fallow health        # complexity + maintainability
 pnpm fallow fix --dry-run # preview auto-fixes for unused exports/deps
 ```
 
-`pnpm ci` runs `pnpm fallow:ci` (`fallow audit`) as a quality gate — it scopes analysis to files changed against the base branch and returns a pass/warn/fail verdict.
+`pnpm ci` runs `pnpm fallow:ci` (`fallow audit`) as a quality gate — it scopes analysis to files changed against the base branch and returns a pass/warn/fail verdict. Configuration lives in `.fallowrc.json`. For the full feature set, see the [fallow docs](https://docs.fallow.tools).
 
-Configuration lives in `.fallowrc.json`. For the full feature set, see the [fallow docs](https://docs.fallow.tools).
+## Reproducing this setup in your own repo
+
+A short checklist for applying these conventions to a greenfield project:
+
+1. `pnpm init`, set `"packageManager": "pnpm@10.x"`.
+2. Create `src/domain`, `src/infra`, `src/utils` on day one, even if empty. Directory shape is a commitment.
+3. Copy the `tsconfig.json` + `tsconfig.domain.json` + `tsconfig.infra.json` trio; adjust the includes/aliases.
+4. Set up `oxlint.config.ts` and `oxfmt.config.ts`. Copy `tools/oxlint-plugins/` and rename the `starter-cloudflare` namespace.
+5. Add `lefthook.yml` with pre-commit (lint + format + `vitest related --project unit`) and pre-push (`vitest run --changed origin/master --project unit`).
+6. Add the `pnpm ci` script: lint → format check → layered typecheck → fallow audit.
+7. Adopt the four test-type filename suffixes (`.unit`, `.browser`, `.integration`, `.e2e`) before writing any tests.
+8. Adopt `*.schema.ts` / `*.types.ts` before introducing any declaration-only module.
+9. Put your HTTP server behind Hono so the runtime stays swappable.
+10. Wire fallow with `.fallowrc.json` to catch dead code and duplication as the project grows.
+
+## Reference
+
+- [`AGENTS.md`](./AGENTS.md) — commands, imports, hook commands, and agent workflow notes.
+- `.fallowrc.json` — fallow configuration.
+- `tools/oxlint-plugins/README.md` — the custom lint plugin, including `domain-no-infra-imports`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A starter template for full-stack apps on **Cloudflare Workers** with **Vite 8**, **React 19**, **TanStack Start**, **Drizzle**, **Vitest 4**, and **pnpm**. See [`AGENTS.md`](./AGENTS.md) for the full command reference.
 
-This README is both **descriptive** (what the repo enforces today) and **prescriptive** (the conventions you should keep if you adopt this starter). Commands and config details live in `AGENTS.md`; this file explains *why* they exist.
+This README is both **descriptive** (what the repo enforces today) and **prescriptive** (the conventions you should keep if you adopt this starter). Commands and config details live in `AGENTS.md`; this file explains _why_ they exist.
 
 ## Toolchain at a glance
 
@@ -46,11 +46,11 @@ Business logic lives in pure TypeScript. Frameworks, databases, and external ser
 
 **Layers:**
 
-- **`src/domain/**`** — one folder per subdomain of the application (`billing/`, `auth/`, `account/`, …). Each subdomain contains its own entities, value objects, use cases, and a `ports/` folder holding the interfaces it needs from the outside world (`user-repository.interface.ts`, `event-publisher.interface.ts`). No imports from `src/infra/**`, no framework globals, no Node/Workers APIs. May import from `src/utils/**`.
-- **`src/infra/**`** — adapter implementations, grouped by *technology concept* and then by *specific technology*: `database/postgres/user-repository.ts`, `messaging/kafka/event-publisher.ts`. Files are named after the *entity or capability* (`user-repository.ts`, `event-publisher.ts`) — never the technology, because the folder already denotes it. Nesting the concrete tech inside the concept makes it obvious what each adapter is fulfilling and keeps the swap path (e.g. `postgres/` → `sqlite/`) local. Infra depends on domain ports; the reverse is never allowed.
-- **`src/utils/**`** — thin wrappers over third-party libraries (`lodash`, `date-fns`, …). The escape hatch that lets domain code use common utilities without defining a port per library. The utility module *is* the port; the library is its implementation, swappable at the utility boundary.
-- **`src/api/**`** — HTTP composition root (Hono). Wires concrete adapters into use cases and exposes them as routes.
-- **`src/webapp/**`** — React + TanStack Start UI. Calls into the API; composes its own adapters where needed.
+- `src/domain/` — one folder per subdomain of the application (`billing/`, `auth/`, `account/`, …). Each subdomain contains its own entities, value objects, use cases, and a `ports/` folder holding the interfaces it needs from the outside world (`user-repository.interface.ts`, `event-publisher.interface.ts`). No imports from `src/infra/`, no framework globals, no Node/Workers APIs. May import from `src/utils/`.
+- `src/infra/` — adapter implementations, grouped by _technology concept_ and then by _specific technology_: `database/postgres/user-repository.ts`, `messaging/kafka/event-publisher.ts`. Files are named after the _entity or capability_ (`user-repository.ts`, `event-publisher.ts`) — never the technology, because the folder already denotes it. Nesting the concrete tech inside the concept makes it obvious what each adapter is fulfilling and keeps the swap path (e.g. `postgres/` → `sqlite/`) local. Infra depends on domain ports; the reverse is never allowed.
+- `src/utils/` — thin wrappers over third-party libraries (`lodash`, `date-fns`, …). The escape hatch that lets domain code use common utilities without defining a port per library. The utility module _is_ the port; the library is its implementation, swappable at the utility boundary.
+- `src/api/` — HTTP composition root (Hono). Wires concrete adapters into use cases and exposes them as routes.
+- `src/webapp/` — React + TanStack Start UI. Calls into the API; composes its own adapters where needed.
 
 **The boundary is enforced three times, on purpose:**
 
@@ -96,12 +96,12 @@ e2e/                            # Playwright specs
 
 Four test types. The filename tells you which, because it reads like the test type it is.
 
-| Type        | Filename                 | Purpose                                                                                                         | Tool                             | Coverage expectation              |
-| ----------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------- |
-| Unit        | `*.unit.test.ts`         | Behavioural units of domain logic                                                                               | Vitest                           | **100%** on domain                |
-| Browser     | `*.browser.test.ts`      | UI components interacting with real DOM APIs                                                                    | Vitest browser mode + Playwright | As needed per component           |
-| Integration | `*.integration.test.ts`  | Adapter implementations reaching real third-party boundaries — e.g. a Drizzle repository against a Postgres testcontainer, or an HTTP client against an MSW handler | Vitest (+ Testcontainers / MSW)  | At least one per adapter          |
-| E2E         | `*.e2e.test.ts`          | Full user flows across multiple routes — signup, login, the journeys that must always work                      | Playwright                       | Critical flows only (top priority)|
+| Type        | Filename                | Purpose                                                                                                                                                             | Tool                             | Coverage expectation               |
+| ----------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------------------------- |
+| Unit        | `*.unit.test.ts`        | Behavioural units of domain logic                                                                                                                                   | Vitest                           | **100%** on domain                 |
+| Browser     | `*.browser.test.ts`     | UI components interacting with real DOM APIs                                                                                                                        | Vitest browser mode + Playwright | As needed per component            |
+| Integration | `*.integration.test.ts` | Adapter implementations reaching real third-party boundaries — e.g. a Drizzle repository against a Postgres testcontainer, or an HTTP client against an MSW handler | Vitest (+ Testcontainers / MSW)  | At least one per adapter           |
+| E2E         | `*.e2e.test.ts`         | Full user flows across multiple routes — signup, login, the journeys that must always work                                                                          | Playwright                       | Critical flows only (top priority) |
 
 Examples from the repo: `src/domain/shared/result.unit.test.ts`, `src/infra/drizzle/user-operations.integration.test.ts`, `e2e/home.e2e.test.ts`, and the oxlint plugin's `tools/oxlint-plugins/rules/domain-no-infra-imports.unit.test.ts`.
 
@@ -120,9 +120,9 @@ Rule of thumb: if a module contains only declarations, use one of these suffixes
 
 ## Quality gates
 
-Every stage has a specific job. Understanding the *why* matters as much as the commands.
+Every stage has a specific job. Understanding the _why_ matters as much as the commands.
 
-- **Pre-commit (lefthook)** — runs `oxlint --fix` and `oxfmt --write` on staged files (auto-restaged), then `vitest related --run --project unit` over the staged files. *Why*: keeps git history clean and readable (no "fix lint" commits), and ensures every commit is **independently releasable** — no commit silently breaks the behaviour of code near the change.
+- **Pre-commit (lefthook)** — runs `oxlint --fix` and `oxfmt --write` on staged files (auto-restaged), then `vitest related --run --project unit` over the staged files. _Why_: keeps git history clean and readable (no "fix lint" commits), and ensures every commit is **independently releasable** — no commit silently breaks the behaviour of code near the change.
 - **Pre-push (lefthook)** — `vitest run --changed origin/master --project unit`. Catches regressions across the whole change set before they leave the machine.
 - **`pnpm ci`** (local + CI) — `oxlint && oxfmt --check . && pnpm typecheck:layers && pnpm fallow:ci`. Read-only quality gate; no fixes, no writes. The source of truth for "is this branch green?"
 - **GitHub Actions** — runs the same gate plus the test matrix (unit, browser, integration).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Business logic lives in pure TypeScript. Frameworks, databases, and external ser
 
 **Layers:**
 
-- **`src/domain/**`** — one folder per subdomain of the application (`billing/`, `auth/`, `account/`, …). Each subdomain contains its own entities, value objects, use cases, and a `ports/` folder holding the interfaces it needs from the outside world (`UserRepository.interface.ts`, `EventPublisher.interface.ts`). No imports from `src/infra/**`, no framework globals, no Node/Workers APIs. May import from `src/utils/**`.
+- **`src/domain/**`** — one folder per subdomain of the application (`billing/`, `auth/`, `account/`, …). Each subdomain contains its own entities, value objects, use cases, and a `ports/` folder holding the interfaces it needs from the outside world (`user-repository.interface.ts`, `event-publisher.interface.ts`). No imports from `src/infra/**`, no framework globals, no Node/Workers APIs. May import from `src/utils/**`.
 - **`src/infra/**`** — adapter implementations, grouped by *technology concept* and then by *specific technology*: `database/postgres/user-repository.ts`, `messaging/kafka/event-publisher.ts`. Files are named after the *entity or capability* (`user-repository.ts`, `event-publisher.ts`) — never the technology, because the folder already denotes it. Nesting the concrete tech inside the concept makes it obvious what each adapter is fulfilling and keeps the swap path (e.g. `postgres/` → `sqlite/`) local. Infra depends on domain ports; the reverse is never allowed.
 - **`src/utils/**`** — thin wrappers over third-party libraries (`lodash`, `date-fns`, …). The escape hatch that lets domain code use common utilities without defining a port per library. The utility module *is* the port; the library is its implementation, swappable at the utility boundary.
 - **`src/api/**`** — HTTP composition root (Hono). Wires concrete adapters into use cases and exposes them as routes.
@@ -67,12 +67,12 @@ src/
   domain/                       # one folder per subdomain; pure business logic + ports
     billing/
       ports/
-        InvoiceRepository.interface.ts
-      Invoice.ts
+        invoice-repository.interface.ts
+      invoice.ts
     auth/
       ports/
-        UserRepository.interface.ts
-      User.ts
+        user-repository.interface.ts
+      user.ts
     account/
       ...
   infra/                        # adapters grouped by technology concept, then specific tech


### PR DESCRIPTION
## Summary

- Rewrites `README.md` from a minimal intro into a conventions manifesto — descriptive of what this repo enforces today *and* prescriptive for greenfield adopters.
- Articulates the hexagonal architecture (domain subdomains with `ports/`; infra grouped by technology concept then specific tech; `src/utils/` as the library-wrapping escape hatch), the four test-type filename suffixes (`.unit` / `.browser` / `.integration` / `.e2e`) with coverage expectations, the `*.schema.ts` / `*.types.ts` exemption, and the rationale behind each quality gate (lefthook, `pnpm ci`, CI).
- Documents runtime choices (Hono for runtime-agnosticism, Cloudflare Workers for cost/speed) and adds a 10-step checklist for reproducing the setup in a greenfield project.

## Test plan

- [ ] Re-read end-to-end: intent is readable without inferring.
- [ ] File paths and script names cross-checked against the repo.